### PR TITLE
Add granite to build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Versions of Ideogram may have been built and made available elsewhere by third-p
 If you want to hack on and build Ideogram yourself, you'll need the following dependencies:
 
 * libgtk-3-dev
+* libgranite-dev
 * meson
 * valac
 


### PR DESCRIPTION
I tried building this and got an error about a missing native dependency.  Installing libgranite-dev solved this and I was able to build.